### PR TITLE
Kafka 기반 주문 생성 비동기 처리 로직 구현

### DIFF
--- a/src/main/java/turtleMart/global/exception/ConflictRequestException.java
+++ b/src/main/java/turtleMart/global/exception/ConflictRequestException.java
@@ -1,0 +1,7 @@
+package turtleMart.global.exception;
+
+public class ConflictRequestException extends CustomRuntimeException {
+    public ConflictRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/turtleMart/global/exception/ErrorCode.java
+++ b/src/main/java/turtleMart/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     ORDER_ITEM_NOT_IN_ORDER(HttpStatus.BAD_REQUEST, "해당 주문에 속하지 않은 상품입니다."),
     ORDER_ITEM_NOT_OWNED_BY_MEMBER(HttpStatus.FORBIDDEN, "해당 회원이 이 주문 항목의 소유자가 아닙니다."),
     NO_REFUNDING_ORDER_ITEM_FOUND(HttpStatus.NOT_FOUND, "환불중인 주문 항목이 없습니다."),
+    ORDER_PRICE_VALIDATION_FAILED(HttpStatus.CONFLICT, "주문 생성 중 가격 정합성 오류: 주문서 가격과 상품 가격이 일치하지 않습니다."),
 
     //장바구니 관련
     PRODUCT_NOT_IN_CART(HttpStatus.NOT_FOUND, "장바구니에 삭제하려는 상품이 존재하지 않음"),

--- a/src/main/java/turtleMart/global/exception/ForbiddenException.java
+++ b/src/main/java/turtleMart/global/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package turtleMart.global.exception;
+
+public class ForbiddenException extends CustomRuntimeException {
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/turtleMart/global/kafka/config/KafkaProducerConfig.java
+++ b/src/main/java/turtleMart/global/kafka/config/KafkaProducerConfig.java
@@ -1,4 +1,4 @@
-package turtleMart.global.config;
+package turtleMart.global.kafka.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/turtleMart/global/kafka/dto/OperationWrapperDto.java
+++ b/src/main/java/turtleMart/global/kafka/dto/OperationWrapperDto.java
@@ -1,0 +1,12 @@
+package turtleMart.global.kafka.dto;
+
+import turtleMart.global.kafka.enums.OperationType;
+
+public record OperationWrapperDto(
+        OperationType operationType,
+        String payload
+) {
+    public static OperationWrapperDto from(OperationType operationType, String payload){
+        return new OperationWrapperDto(operationType, payload);
+    }
+}

--- a/src/main/java/turtleMart/global/kafka/enums/OperationType.java
+++ b/src/main/java/turtleMart/global/kafka/enums/OperationType.java
@@ -1,0 +1,10 @@
+package turtleMart.global.kafka.enums;
+
+public enum OperationType {
+    PRICE_CHANGE,
+    INVENTORY_OVERRIDE,
+    COMBINATION_DELETE,
+    INVENTORY_UPDATE,
+    COMBINATION_STATUS,
+    ORDER_CREATE
+}

--- a/src/main/java/turtleMart/global/kafka/listener/OrderKafkaListener.java
+++ b/src/main/java/turtleMart/global/kafka/listener/OrderKafkaListener.java
@@ -1,0 +1,31 @@
+package turtleMart.global.kafka.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import turtleMart.global.kafka.dto.OperationWrapperDto;
+import turtleMart.global.utill.JsonHelper;
+import turtleMart.order.dto.request.OrderWrapperRequest;
+import turtleMart.order.service.OrderService;
+
+@RequiredArgsConstructor
+@Component
+public class OrderKafkaListener {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OrderService orderService;
+
+    @KafkaListener(topics = "order_create_topic", groupId = "order-group")
+    public void listenOrderCreate(@Header(KafkaHeaders.RECEIVED_KEY) String key, String value){
+        OperationWrapperDto wrapperDto = JsonHelper.fromJson(value, OperationWrapperDto.class);
+        String payload = wrapperDto.payload();
+        OrderWrapperRequest orderWrapperRequest = JsonHelper.fromJson(payload, OrderWrapperRequest.class);
+
+        orderService.createOrder(orderWrapperRequest);
+    }
+}

--- a/src/main/java/turtleMart/global/kafka/listener/OrderKafkaListener.java
+++ b/src/main/java/turtleMart/global/kafka/listener/OrderKafkaListener.java
@@ -1,9 +1,7 @@
 package turtleMart.global.kafka.listener;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
@@ -16,8 +14,6 @@ import turtleMart.order.service.OrderService;
 @Component
 public class OrderKafkaListener {
 
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final KafkaTemplate<String, String> kafkaTemplate;
     private final OrderService orderService;
 
     @KafkaListener(topics = "order_create_topic", groupId = "order-group")

--- a/src/main/java/turtleMart/global/kafka/listener/ProductKafkaListener.java
+++ b/src/main/java/turtleMart/global/kafka/listener/ProductKafkaListener.java
@@ -1,0 +1,66 @@
+package turtleMart.global.kafka.listener;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.stereotype.Component;
+import turtleMart.global.kafka.dto.OperationWrapperDto;
+import turtleMart.global.kafka.enums.OperationType;
+import turtleMart.global.utill.JsonHelper;
+
+import java.time.Duration;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class ProductKafkaListener {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @KafkaListener(topics = "order_make_topic", groupId = "order-group")
+    public void listen(@Header(KafkaHeaders.RECEIVED_KEY) String key, String value) {
+        try {
+            OperationWrapperDto wrapperDto = JsonHelper.fromJson(value, OperationWrapperDto.class);
+            OperationType type = wrapperDto.operationType();
+
+            switch (type) {
+                case PRICE_CHANGE -> {
+                    String lockKey = "softLock:priceChange:combination:" + key;
+                    if (Boolean.FALSE.equals(redisTemplate.hasKey(lockKey))) {
+                        // 소프트락이 없으면 걸고 재발송
+                        redisTemplate.opsForValue().set(lockKey, false, Duration.ofMinutes(4));
+                        Thread.sleep(1000);
+                        kafkaTemplate.send("order_make_topic", key, value);
+                    } else {
+                        // 소프트락이 이미 존재하면 가격변동 처리용 새 토픽에 발행
+                        kafkaTemplate.send("", key, value);/*TODO 토픽 이름 넣기 */
+                    }
+                }
+                case ORDER_CREATE -> {
+                    //key 역직렬화 및 가격 변경중인지 확인
+                    List<Long> productOptionCombinationIdList = JsonHelper.fromJsonToList(key, new TypeReference<>() {});
+                    // 주문 요청 상품 중 하나라도 가격 변경 중이라면 주문 생성 중단
+                    for(Long combinationId : productOptionCombinationIdList){
+                        String lockKey = "softLock:priceChange:combination:" + combinationId.toString();
+                        if(Boolean.TRUE.equals(redisTemplate.opsForValue().get(lockKey))){ //가격 변동 처리 중 상태(Redis value=true)
+                            kafkaTemplate.send("order_make_topic", key, value); //재발행
+                            return;
+                        }
+                    }
+                    // 가격 변동이 끝났다면 주문 생성 로직 실행, 주문 생성 토픽으로 넘기기
+                    kafkaTemplate.send("order_create_topic", key, value);
+                }
+                default -> log.error("알 수 없는 타입이 입력되었습니다.");
+            }
+        } catch (Exception e) {
+            log.error("Kafka message handling error", e);
+        }
+    }
+}

--- a/src/main/java/turtleMart/order/controller/OrderController.java
+++ b/src/main/java/turtleMart/order/controller/OrderController.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import turtleMart.order.dto.request.CartOrderSheetRequest;
 import turtleMart.order.dto.request.OrderItemStatusRequest;
-import turtleMart.order.dto.request.OrderRequest;
+import turtleMart.order.dto.request.OrderWrapperRequest;
 import turtleMart.order.dto.response.MemberOrderListResponse;
 import turtleMart.order.dto.response.OrderDetailResponse;
 import turtleMart.order.dto.response.TotalOrderedQuantityResponse;
@@ -28,12 +28,12 @@ public class OrderController {
     @PostMapping("/orders")
     public ResponseEntity<Void> createOrder(
             @RequestParam String items, //상품옵션Id1:수량,상품옵션Id2:수량 형식으로 입력
-            @RequestBody OrderRequest request
+            @RequestBody OrderWrapperRequest request
             /*TODO JWT 통해서 회원 ID 가져오기*/
     ) {
         List<CartOrderSheetRequest> productNameAndQuantityList = CartOrderSheetRequest.splitItemIdAndQuantity(items);
 
-        orderService.createOrder(1L, productNameAndQuantityList, request);
+        orderService.tryOrder(1L, productNameAndQuantityList, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/turtleMart/order/dto/request/OrderRequest.java
+++ b/src/main/java/turtleMart/order/dto/request/OrderRequest.java
@@ -1,25 +1,17 @@
 package turtleMart.order.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-
-import java.util.List;
 
 public record OrderRequest(
         @NotNull(message = "장바구니 항목 ID 리스트는 필수입니다.")
-        List<Long> cartItemIdList,
+        Long cartItemId,
 
-        @NotBlank(message = "결제 수단을 입력해주세요.")
-        String paymentMethod,
+        Long productOptionId,
 
-        @NotBlank(message = "카드사를 입력해주세요.")
-        String cardCompany,
+        @NotNull(message = "단품 가격 입력은 필수입니다.")
+        Integer price, // 주문서 가격을 그대로 스냅샷으로 들고와야한다.
 
-        int installmentMonth,
-
-        String deliveryRequest,
-
-        @NotNull(message = "주소 ID는 필수입니다.")
-        Long addressId
+        @NotNull(message = "전체 가격는 필수입니다.")
+        Integer totalPrice
 ) {
 }

--- a/src/main/java/turtleMart/order/dto/request/OrderWrapperRequest.java
+++ b/src/main/java/turtleMart/order/dto/request/OrderWrapperRequest.java
@@ -1,0 +1,28 @@
+package turtleMart.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import turtleMart.delivery.dto.reqeust.CreateDeliveryRequest;
+import turtleMart.payment.dto.request.PaymentRequest;
+
+import java.util.List;
+
+public record OrderWrapperRequest(
+        @NotNull(message = "주문상품 관련 정보 입력은 필수입니다.")
+        List<OrderRequest> orderList,
+        List<CartOrderSheetRequest> itemList, //정보 입력 불필요
+
+        @NotNull(message = "결재 관련 정보 입력은 필수입니다.")
+        PaymentRequest payment,
+
+        @NotNull(message = "배송 관련 정보 입력은 필수입니다.")
+        CreateDeliveryRequest delivery
+) {
+        public static OrderWrapperRequest updateItemList(OrderWrapperRequest wrapperRequest, List<CartOrderSheetRequest> itemList){
+                return new OrderWrapperRequest(
+                        wrapperRequest.orderList,
+                        itemList,
+                        wrapperRequest.payment,
+                        wrapperRequest.delivery
+                );
+        }
+}

--- a/src/main/java/turtleMart/order/dto/request/PaymentWrapperRequest.java
+++ b/src/main/java/turtleMart/order/dto/request/PaymentWrapperRequest.java
@@ -1,0 +1,13 @@
+package turtleMart.order.dto.request;
+
+import turtleMart.delivery.dto.reqeust.CreateDeliveryRequest;
+import turtleMart.payment.dto.request.PaymentRequest;
+
+public record PaymentWrapperRequest(
+        PaymentRequest payment,
+        CreateDeliveryRequest delivery
+) {
+    public static PaymentWrapperRequest from(PaymentRequest payment, CreateDeliveryRequest delivery){
+        return new PaymentWrapperRequest(payment, delivery);
+    }
+}

--- a/src/main/java/turtleMart/payment/dto/request/PaymentRequest.java
+++ b/src/main/java/turtleMart/payment/dto/request/PaymentRequest.java
@@ -3,8 +3,6 @@ package turtleMart.payment.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import turtleMart.order.dto.request.OrderRequest;
-import turtleMart.order.entity.Order;
 import turtleMart.payment.entity.PaymentMethod;
 
 public record PaymentRequest(
@@ -15,14 +13,4 @@ public record PaymentRequest(
         @NotBlank String cardCompany,
         int installmentMonth
 ) {
-    public static PaymentRequest from(Order order, Long memberId, OrderRequest request) {
-        return new PaymentRequest(
-                order.getId(),
-                memberId,
-                order.getTotalPrice(),
-                PaymentMethod.valueOf(request.paymentMethod()),
-                request.cardCompany(),
-                request.installmentMonth()
-        );
-    }
 }


### PR DESCRIPTION
### 주요 변경 사항
- 주문 생성 요청을 Kafka 기반 비동기 처리 방식으로 리팩토링했습니다.
- 기존 동기 처리 방식에서 Kafka Producer → Listener 구조로 변경하여 가격 변동 중인 상태에 대한 처리와 주문 생성을 분리했습니다.
- Kafka 메시지 구조는 Wrapper 구조를 도입하여 `operationType`에 따라 메시지 유형을 구분할 수 있도록 설계했습니다.

### 변경 상세
1. Kafka 메시지 Wrapper 도입
   - `OperationWrapperDto`를 통해 메시지 유형(`operationType`)과 실제 payload를 분리
   - 2단계 파싱 구조 적용

2. 리스너 분기 처리
   - `PRICE_CHANGE` 요청일 경우 소프트락 처리 후 재발행 or 가격 변경 토픽 전송
   - `ORDER_CREATE` 요청일 경우 Redis soft lock 상태 확인 후 처리

3. 주문 생성 서비스 로직 분리
   - `tryOrder`: 주문 요청 시 Kafka로 메시지 발행
   - `createOrder`: 가격 검증 후 실제 주문 생성 및 결재, 장바구니 주문 완료 상품 삭제 처리

### 참고사항
ProductKafkaListener, OrderKafkaListener,
OrderService의 tryOrder(), createOrder()위주로 보시면 됩니다.

